### PR TITLE
added data-providers endpoint definitions (list, get, create, update,…

### DIFF
--- a/bruno/Embeddable-API/APIs/data-providers/create-data-provider.bru
+++ b/bruno/Embeddable-API/APIs/data-providers/create-data-provider.bru
@@ -30,15 +30,6 @@ body:json {
   }
 }
 
-vars:pre-request {
-  /*
-   * Use api.eu.embeddable.com for EU region
-   * Use api.us.embeddable.com if your region is US
-  */
-  
-  host: https://api.eu.embeddable.com
-}
-
 settings {
   encodeUrl: true
 }

--- a/bruno/Embeddable-API/APIs/data-providers/create-data-provider.bru
+++ b/bruno/Embeddable-API/APIs/data-providers/create-data-provider.bru
@@ -1,0 +1,44 @@
+meta {
+  name: Create data provider
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{host}}/api/v1/data-providers
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    /*
+     * Creates a new data provider.
+     * Notes:
+     *  - type must be "cube" (translates to CUBE_CLOUD)
+     *  - name cannot be "internal" (reserved)
+     *  - secretKey must be encrypted in the database
+     *  - Returns 201 on success, 400 on error
+     *  - Response format matches GET /api/v1/data-providers/{name}
+     */
+    "name": "my-provider",
+    "type": "cube",
+    "credentials": {
+      "secretKey": "my-encrypted-secret",
+      "instanceUrl": "https://cube-instance-url"
+    }
+  }
+}
+
+vars:pre-request {
+  /*
+   * Use api.eu.embeddable.com for EU region
+   * Use api.us.embeddable.com if your region is US
+  */
+  
+  host: https://api.eu.embeddable.com
+}
+
+settings {
+  encodeUrl: true
+}

--- a/bruno/Embeddable-API/APIs/data-providers/create-data-provider.bru
+++ b/bruno/Embeddable-API/APIs/data-providers/create-data-provider.bru
@@ -12,22 +12,17 @@ post {
 
 body:json {
   {
-    /*
-     * Creates a new data provider.
-     * Notes:
-     *  - type must be "cube" (translates to CUBE_CLOUD)
-     *  - name cannot be "internal" (reserved)
-     *  - secretKey must be encrypted in the database
-     *  - Returns 201 on success, 400 on error
-     *  - Response format matches GET /api/v1/data-providers/{name}
-     */
-    "name": "my-provider",
+    "name": "{{providerName}}",
     "type": "cube",
     "credentials": {
       "secretKey": "my-encrypted-secret",
       "instanceUrl": "https://cube-instance-url"
     }
   }
+}
+
+vars:pre-request {
+  providerName: staging
 }
 
 settings {

--- a/bruno/Embeddable-API/APIs/data-providers/delete-data-provider.bru
+++ b/bruno/Embeddable-API/APIs/data-providers/delete-data-provider.bru
@@ -5,9 +5,13 @@ meta {
 }
 
 delete {
-  url: {{host}}/api/v1/data-providers/{name}
+  url: {{host}}/api/v1/data-providers/{{providerName}}
   body: none
   auth: inherit
+}
+
+vars:pre-request {
+  providerName: staging
 }
 
 settings {

--- a/bruno/Embeddable-API/APIs/data-providers/delete-data-provider.bru
+++ b/bruno/Embeddable-API/APIs/data-providers/delete-data-provider.bru
@@ -5,18 +5,9 @@ meta {
 }
 
 delete {
-  url: {{host}}/api/v1/data-providers/{{providerName}}
+  url: {{host}}/api/v1/data-providers/{name}
   body: none
   auth: inherit
-}
-
-vars:pre-request {
-  /*
-   * Use api.eu.embeddable.com for EU region
-   * Use api.us.embeddable.com if your region is US
-   */
-  host: https://api.eu.embeddable.com
-  providerName: my-provider
 }
 
 settings {

--- a/bruno/Embeddable-API/APIs/data-providers/delete-data-provider.bru
+++ b/bruno/Embeddable-API/APIs/data-providers/delete-data-provider.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Delete data provider
+  type: http
+  seq: 2
+}
+
+delete {
+  url: {{host}}/api/v1/data-providers/{{providerName}}
+  body: none
+  auth: inherit
+}
+
+vars:pre-request {
+  /*
+   * Use api.eu.embeddable.com for EU region
+   * Use api.us.embeddable.com if your region is US
+   */
+  host: https://api.eu.embeddable.com
+  providerName: my-provider
+}
+
+settings {
+  encodeUrl: true
+}

--- a/bruno/Embeddable-API/APIs/data-providers/folder.bru
+++ b/bruno/Embeddable-API/APIs/data-providers/folder.bru
@@ -1,0 +1,9 @@
+meta {
+  name: data-providers
+}
+
+docs {
+  # data-providers API
+  
+  Learn more [here](https://docs.embeddable.com/deployment/bring-your-own-cube)
+}

--- a/bruno/Embeddable-API/APIs/data-providers/list-data-providers.bru
+++ b/bruno/Embeddable-API/APIs/data-providers/list-data-providers.bru
@@ -1,0 +1,23 @@
+meta {
+  name: List data providers
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{host}}/api/v1/data-providers
+  body: none
+  auth: inherit
+}
+
+vars:pre-request {
+  /*
+   * Use api.eu.embeddable.com for EU region
+   * Use api.us.embeddable.com if your region is US
+   */
+  host: https://api.eu.embeddable.com
+}
+
+settings {
+  encodeUrl: true
+}

--- a/bruno/Embeddable-API/APIs/data-providers/list-data-providers.bru
+++ b/bruno/Embeddable-API/APIs/data-providers/list-data-providers.bru
@@ -10,14 +10,6 @@ get {
   auth: inherit
 }
 
-vars:pre-request {
-  /*
-   * Use api.eu.embeddable.com for EU region
-   * Use api.us.embeddable.com if your region is US
-   */
-  host: https://api.eu.embeddable.com
-}
-
 settings {
   encodeUrl: true
 }

--- a/bruno/Embeddable-API/APIs/data-providers/read-data-provider.bru
+++ b/bruno/Embeddable-API/APIs/data-providers/read-data-provider.bru
@@ -5,9 +5,13 @@ meta {
 }
 
 get {
-  url: {{host}}/api/v1/data-providers/{name}
+  url: {{host}}/api/v1/data-providers/{{providerName}}
   body: none
   auth: inherit
+}
+
+vars:pre-request {
+  providerName: staging
 }
 
 settings {

--- a/bruno/Embeddable-API/APIs/data-providers/read-data-provider.bru
+++ b/bruno/Embeddable-API/APIs/data-providers/read-data-provider.bru
@@ -5,19 +5,9 @@ meta {
 }
 
 get {
-  url: {{host}}/api/v1/data-providers/{{providerName}}
+  url: {{host}}/api/v1/data-providers/{name}
   body: none
   auth: inherit
-}
-
-vars:pre-request {
-  /*
-   * Use api.eu.embeddable.com for EU region
-   * Use api.us.embeddable.com if your region is US
-  */
-
-  host: https://api.eu.embeddable.com
-  providerName: my-provider
 }
 
 settings {

--- a/bruno/Embeddable-API/APIs/data-providers/read-data-provider.bru
+++ b/bruno/Embeddable-API/APIs/data-providers/read-data-provider.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Read data provider
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{host}}/api/v1/data-providers/{{providerName}}
+  body: none
+  auth: inherit
+}
+
+vars:pre-request {
+  /*
+   * Use api.eu.embeddable.com for EU region
+   * Use api.us.embeddable.com if your region is US
+  */
+
+  host: https://api.eu.embeddable.com
+  providerName: my-provider
+}
+
+settings {
+  encodeUrl: true
+}

--- a/bruno/Embeddable-API/APIs/data-providers/update-data-provider.bru
+++ b/bruno/Embeddable-API/APIs/data-providers/update-data-provider.bru
@@ -5,27 +5,23 @@ meta {
 }
 
 put {
-  url: {{host}}/api/v1/data-providers/{name}
+  url: {{host}}/api/v1/data-providers/{{providerName}}
   body: json
   auth: inherit
 }
 
 body:json {
   {
-    /*
-     * Updates an existing data provider.
-     * Notes:
-     *  - type must be "cube" (translates to CUBE_CLOUD)
-     *  - Updates external system credential under the given name
-     *  - Returns 200 on success
-     *  - Response format matches GET /api/v1/data-providers/{name}
-     */
     "type": "cube",
     "credentials": {
       "secretKey": "updated-encrypted-secret",
       "instanceUrl": "https://updated-cube-instance-url"
     }
   }
+}
+
+vars:pre-request {
+  providerName: staging
 }
 
 settings {

--- a/bruno/Embeddable-API/APIs/data-providers/update-data-provider.bru
+++ b/bruno/Embeddable-API/APIs/data-providers/update-data-provider.bru
@@ -1,0 +1,43 @@
+meta {
+  name: Update data provider
+  type: http
+  seq: 5
+}
+
+put {
+  url: {{host}}/api/v1/data-providers/{{providerName}}
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    /*
+     * Updates an existing data provider.
+     * Notes:
+     *  - type must be "cube" (translates to CUBE_CLOUD)
+     *  - Updates external system credential under the given name
+     *  - Returns 200 on success
+     *  - Response format matches GET /api/v1/data-providers/{name}
+     */
+    "type": "cube",
+    "credentials": {
+      "secretKey": "updated-encrypted-secret",
+      "instanceUrl": "https://updated-cube-instance-url"
+    }
+  }
+}
+
+vars:pre-request {
+  /*
+   * Use api.eu.embeddable.com for EU region
+   * Use api.us.embeddable.com if your region is US
+  */
+  
+  host: https://api.eu.embeddable.com
+  providerName: my-provider
+}
+
+settings {
+  encodeUrl: true
+}

--- a/bruno/Embeddable-API/APIs/data-providers/update-data-provider.bru
+++ b/bruno/Embeddable-API/APIs/data-providers/update-data-provider.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 put {
-  url: {{host}}/api/v1/data-providers/{{providerName}}
+  url: {{host}}/api/v1/data-providers/{name}
   body: json
   auth: inherit
 }
@@ -26,16 +26,6 @@ body:json {
       "instanceUrl": "https://updated-cube-instance-url"
     }
   }
-}
-
-vars:pre-request {
-  /*
-   * Use api.eu.embeddable.com for EU region
-   * Use api.us.embeddable.com if your region is US
-  */
-  
-  host: https://api.eu.embeddable.com
-  providerName: my-provider
 }
 
 settings {


### PR DESCRIPTION
… delete)

- Added API definitions for managing data providers:
  - GET /api/v1/data-providers (list all)
  - GET /api/v1/data-providers/{name} (read single)
  - POST /api/v1/data-providers (create)
  - PUT /api/v1/data-providers/{name} (update)
  - DELETE /api/v1/data-providers/{name} (delete)

- Included region-aware host comments (EU/US)
- Documented validation rules, success/error codes, and response references
- Ensured consistency in formatting with existing environment endpoint definitions